### PR TITLE
Agregar archivos .md para resolver error 404 en la página de documentación

### DIFF
--- a/docs/community-scripts.md
+++ b/docs/community-scripts.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/create-usb.md
+++ b/docs/create-usb.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/es/_navbar.md
+++ b/docs/es/_navbar.md
@@ -1,0 +1,3 @@
+- Idioma
+    - [:us: English](/)
+    - [🇲🇽 Español](/es/)

--- a/docs/es/crear-usb.md
+++ b/docs/es/crear-usb.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/especificaciones-sistema.md 
+++ b/docs/es/especificaciones-sistema.md 
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/extras.md
+++ b/docs/es/extras.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/instalar-gdl.md
+++ b/docs/es/instalar-gdl.md
@@ -1,0 +1,1 @@
+#### Instalación de GoldenDog Linux

--- a/docs/es/redes.md
+++ b/docs/es/redes.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/scripts-comunidad.md
+++ b/docs/es/scripts-comunidad.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/teams-comunidad.md
+++ b/docs/es/teams-comunidad.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/teams-dev.md
+++ b/docs/es/teams-dev.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/teams-documentacion.md
+++ b/docs/es/teams-documentacion.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/teams-testeo.md
+++ b/docs/es/teams-testeo.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/es/teams-web.md
+++ b/docs/es/teams-web.md
@@ -1,0 +1,1 @@
+### En mantenimiento

--- a/docs/extras-md.md
+++ b/docs/extras-md.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/socials.md
+++ b/docs/socials.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/system-specs.md
+++ b/docs/system-specs.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/teams-community.md
+++ b/docs/teams-community.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/teams-dev.md
+++ b/docs/teams-dev.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/teams-documentation.md
+++ b/docs/teams-documentation.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/teams-testing.md
+++ b/docs/teams-testing.md
@@ -1,0 +1,1 @@
+#### In maintenance

--- a/docs/teams-web.md
+++ b/docs/teams-web.md
@@ -1,0 +1,1 @@
+#### In maintenance


### PR DESCRIPTION
Este pull request añade los archivos `.md` necesarios para resolver el error 404 que se estaba presentando en la página de documentación, tanto en la raíz como en la carpeta "es".